### PR TITLE
README step typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ It can be configured to run periodically using CloudWatch events.
 4. Create a CloudWatch rule:
     - Event Source: Schedule -> Fixed rate of 1 hour
     - Targets: Lambda Function (the one created in step #1)
-    - Configure input -> Constant (JSON text) and paste your config (as per step #4)
+    - Configure input -> Constant (JSON text) and paste your config (as per previous step)
 
 
 #### File Naming


### PR DESCRIPTION
Trivial typo fix - in the README, step 4 says to paste your config, 
"as per step #4" - I believe it meant the previous step, with the example test event.
