### PR TITLE
Update VPC instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ s3://${S3_BUCKET}${ROOT}/YYYY-MM-DD/YYYY-MM-DD@HH-mm-ss.backup
 #### AWS Firewall
 
 - If you run the Lambda function outside a VPC, you must enable public access to your database instance, a non VPC Lambda function executes on the public internet.
-- If you run the Lambda function inside a VPC (not tested), you must allow access from the Lambda Security Group to your database instance. Also you must add a NAT gateway to your VPC so the Lambda can connect to S3.
+- If you run the Lambda function inside a VPC, you must allow access from the Lambda Security Group to your database instance. Also you must either add a NAT gateway ([chargeable](https://aws.amazon.com/vpc/pricing/)) to your VPC so the Lambda can connect to S3 over the Internet, or add an [S3 VPC endpoint (free)](https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-s3.html) and allow traffic to the appropriate S3 prefixlist.
 
 #### Encryption
 


### PR DESCRIPTION
I have this lambda code successfully running inside a VPC.

You can, as the README said, add a NAT gateway, but that [costs extra
money](https://aws.amazon.com/vpc/pricing/) - you can instead create
a [VPC endpoint for S3](https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-s3.html)
within your VPC, and add a security group egress rule that allows
traffic from the security group to the appropriate S3 prefixlist based
on the region, if you are blocking egress by default.

You can find the appropriate PrefixList for a region via aws-cli:

`aws ec2 describe-prefix-lists --region eu-west-2`

Updated the README to reflect this.
