### PR TITLE
enhancement: add config for S3 Storage Class

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -6,5 +6,6 @@ module.exports = {
     PGDUMP_PATH: path.join(__dirname, '../bin/postgres-13.3'),
     // maximum time allowed to connect to postgres before a timeout occurs
     PGCONNECT_TIMEOUT: 15,
-    USE_IAM_AUTH: false
+    USE_IAM_AUTH: false,
+    S3_STORAGE_CLASS: 'STANDARD'
 }

--- a/lib/upload-s3.js
+++ b/lib/upload-s3.js
@@ -12,7 +12,8 @@ async function uploadS3(stream, config, key) {
     const result = await s3.upload({
         Key: key,
         Bucket: config.S3_BUCKET,
-        Body: stream
+        Body: stream,
+        StorageClass: config.S3_STORAGE_CLASS
     }).promise()
 
     console.log('Uploaded to', result.Location)


### PR DESCRIPTION
You can specify StorageClass.

Usually, pgdump backup files aren't accessed so frequently.

Setting appropriate storage class may reduce storage costs.